### PR TITLE
Use development config if the requested config does not exist

### DIFF
--- a/lib/kumo_keisei/environment_config.rb
+++ b/lib/kumo_keisei/environment_config.rb
@@ -105,6 +105,7 @@ class KumoKeisei::EnvironmentConfig
   end
 
   def env_config
-    @file_loader.load_config(env_config_file_name)
+    config = @file_loader.load_config(env_config_file_name)
+    config || @file_loader.load_config('development.yml')
   end
 end


### PR DESCRIPTION
It's a waste of time to create new config templates for all developer environments.