### PR TITLE
Expose `Stack#environment_config` publicly

### DIFF
--- a/lib/kumo_keisei/stack.rb
+++ b/lib/kumo_keisei/stack.rb
@@ -27,7 +27,7 @@ module KumoKeisei
       self.new(app_name, environment_name).exists?
     end
 
-    def initialize(app_name, environment_name, config, options = { confirmation_timeout: 30, waiter_delay: 20, waiter_attempts: 90} )
+    def initialize(app_name, environment_name, config = {}, options = { confirmation_timeout: 30, waiter_delay: 20, waiter_attempts: 90} )
       @app_name = app_name
       @env_name = environment_name
       @stack_name = "#{app_name}-#{ environment_name }"

--- a/lib/kumo_keisei/stack.rb
+++ b/lib/kumo_keisei/stack.rb
@@ -38,7 +38,6 @@ module KumoKeisei
     end
 
     def apply!
-      config
       if updatable?
         update!
       else


### PR DESCRIPTION
Redbubble's `script/apply_env` needs to access the stack's environment configuration in order to set the `DB_HOST` environment variable on Docker Cloud. This will allow us to specify that the staging environment should use the EY Cloud database.

Unfortunately this breaks the public interface of `Stack` 😞 