### PR TITLE
Auto spec helper

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,6 @@ steps:
     command: script/unit_test.sh
     agents:
       location: aws
-  - wait
   - name: ':gem: build'
     command: script/build.sh
     agents:

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/spec/lib/kumo_keisei/cloud_formation_stack_spec.rb
+++ b/spec/lib/kumo_keisei/cloud_formation_stack_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'ostruct'
 
 describe KumoKeisei::CloudFormationStack do

--- a/spec/lib/kumo_keisei/console_jockey_spec.rb
+++ b/spec/lib/kumo_keisei/console_jockey_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'ostruct'
 
 describe KumoKeisei::ConsoleJockey do

--- a/spec/lib/kumo_keisei/environment_config_spec.rb
+++ b/spec/lib/kumo_keisei/environment_config_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe KumoKeisei::EnvironmentConfig do
   let(:env_name) { 'the_jungle' }
   let(:config_dir_path) { '/var/config' }

--- a/spec/lib/kumo_keisei/file_loader_spec.rb
+++ b/spec/lib/kumo_keisei/file_loader_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe KumoKeisei::FileLoader do
   let(:config_dir_path) { '/the/garden/path' }
   let(:options) { { config_dir_path: config_dir_path } }

--- a/spec/lib/kumo_keisei/parameter_builder_spec.rb
+++ b/spec/lib/kumo_keisei/parameter_builder_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe KumoKeisei::ParameterBuilder do
   subject  {described_class.new(dynamic_params, file_path) }
   let(:dynamic_params) { {} }

--- a/spec/lib/kumo_keisei/stack_spec.rb
+++ b/spec/lib/kumo_keisei/stack_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'ostruct'
 
 describe KumoKeisei::Stack do


### PR DESCRIPTION
require 'spec_helper' can be config

Remove all the require 'spec_helper' in test

Making the build concurrent with rpsec test in pipeline as it doesn't push gem to anywhere